### PR TITLE
Add item post resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: cimg/ruby:2.7.2-node
+      - image: cimg/ruby:2.7.1-node
       - image: circleci/postgres:11.2
     steps:
       - checkout
@@ -15,7 +15,7 @@ jobs:
   test:
     parallelism: 3
     docker:
-      - image: cimg/ruby:2.7.2-node
+      - image: cimg/ruby:2.7.1-node
       - image: circleci/postgres:9.5-alpine
         environment:
           POSTGRES_USER: rails_guilded_rose_llc

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.2'
+ruby '2.7.1'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '~> 6.1.3', '>= 6.1.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,7 +249,7 @@ DEPENDENCIES
   tzinfo-data
 
 RUBY VERSION
-   ruby 2.7.2p137
+   ruby 2.7.1p83
 
 BUNDLED WITH
    2.2.16

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -7,4 +7,14 @@ class Api::V1::ItemsController < ApplicationController
     item = Item.find(params[:id])
     json_response(item)
   end
+
+  def create
+    item = Item.create!(item_params)
+    json_response(item, :created)
+  end
+
+  private
+  def item_params
+    params.permit(:name, :sell_in, :quality)
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,5 @@
 class Item < ActiveRecord::Base
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
   validates :sell_in, presence: true
   validates :quality, presence: true
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -48,7 +48,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = false
+  config.use_transactional_fixtures = true
 
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)

--- a/spec/requests/items_spec.rb
+++ b/spec/requests/items_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Items API', type: :request do
-  describe 'GET /items', type: :request do
+  describe 'GET api/v1/items', type: :request do
     it 'returns a successful response when there are no items' do
 
       get '/api/v1/items'
@@ -44,10 +44,12 @@ RSpec.describe 'Items API', type: :request do
     end
   end
 
-  describe 'GET /items/:id' do
+  describe 'GET api/v1/items/:id' do
     context 'when the record exists' do
       it 'returns the item' do
-        items = FactoryBot.create_list(:item, 10)
+        items = [
+          FactoryBot.create(:item, name: 'Raspberry', sell_in: 5, quality: 11),
+        ]
         item_id = items.first.id
 
         get "/api/v1/items/#{item_id}"
@@ -57,7 +59,9 @@ RSpec.describe 'Items API', type: :request do
       end
 
       it 'returns status code 200' do
-        items = FactoryBot.create_list(:item, 10)
+        items = [
+          FactoryBot.create(:item, name: 'Raspberry', sell_in: 5, quality: 11),
+        ]
         item_id = items.first.id
 
         get "/api/v1/items/#{item_id}"
@@ -81,6 +85,45 @@ RSpec.describe 'Items API', type: :request do
         get "/api/v1/items/#{item_id}"
 
         expect(response.body).to match(/Couldn't find Item/)
+      end
+    end
+  end
+
+  describe 'POST api/v1/items' do
+    context 'when item post request attributes are valid' do
+      it 'creates a new item in the database' do
+        valid_attributes = {name: 'Asparagus', sell_in: 10, quality: 25}
+
+        expect { post '/api/v1/items', params: valid_attributes }.to change(Item, :count).by(+1)
+      end
+
+      it 'returns status code 201' do
+        valid_attributes = {name: 'Asparagus', sell_in: 10, quality: 25}
+        post '/api/v1/items', params: valid_attributes
+
+        expect(response).to have_http_status(201)
+      end
+    end
+
+    context 'wwhen item post request attributes are invalid' do
+      it 'does not create a new item in the database' do
+        invalid_attributes = {title: 'Lorem Ipsum'}
+
+        expect { post '/api/v1/items', params: invalid_attributes }.to change(Item, :count).by(0)
+      end
+
+      it 'returns status code 422 for invalid attributes' do
+        invalid_attributes = {title: 'Lorem Ipsum'}
+        post '/api/v1/items', params: invalid_attributes
+
+        expect(response).to have_http_status(422)
+      end
+
+      it 'returns a failure message for missing attributes' do
+        invalid_attributes = {title: 'Lorem Ipsum'}
+        post '/api/v1/items', params: invalid_attributes
+
+        expect(response.body).to match(/Validation failed: Name can't be blank/)
       end
     end
   end


### PR DESCRIPTION
**Summary**

The item-post-endpoint branch is adding the infrastructure including the controller show action, route, and tests for POST /items/.

Figure. Successful Postman request
<img width="577" alt="Post" src="https://user-images.githubusercontent.com/43938783/118150530-482abb80-b3d8-11eb-947c-ba5182ef1b0a.png">
