### PR TITLE
Snake case params hash sell in key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: cimg/ruby:2.7.1-node
+      - image: cimg/ruby:2.7.2-node
       - image: circleci/postgres:11.2
     steps:
       - checkout
@@ -15,7 +15,7 @@ jobs:
   test:
     parallelism: 3
     docker:
-      - image: cimg/ruby:2.7.1-node
+      - image: cimg/ruby:2.7.2-node
       - image: circleci/postgres:9.5-alpine
         environment:
           POSTGRES_USER: rails_guilded_rose_llc

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.1'
+ruby '2.7.2'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '~> 6.1.3', '>= 6.1.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,7 +248,7 @@ DEPENDENCIES
   tzinfo-data
 
 RUBY VERSION
-   ruby 2.7.1p83
+   ruby 2.7.2p137
 
 BUNDLED WITH
    2.1.4

--- a/app/controllers/api/v1/item_presenter.rb
+++ b/app/controllers/api/v1/item_presenter.rb
@@ -9,4 +9,12 @@ class Api::V1::ItemPresenter < ApplicationController
       sellIn: item.sell_in
     }
   end
+
+  def self.snakecase_keys(params)
+    {
+      'name' => params[:name],
+      'sell_in' => params[:sellIn],
+      'quality' => params[:quality]
+    }
+  end
 end

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -15,7 +15,8 @@ class Api::V1::ItemsController < ApplicationController
   end
 
   def create
-    item = Item.create!(item_params)
+    item_presenter = Api::V1::ItemPresenter
+    item = Item.create!(item_presenter.snakecase_keys(params))
     json_item = Api::V1::ItemPresenter.to_json(item)
     json_response(json_item, :created)
   end

--- a/spec/requests/item_presenter_spec.rb
+++ b/spec/requests/item_presenter_spec.rb
@@ -15,12 +15,62 @@ describe Api::V1::ItemPresenter do
     end
   end
 
-  it 'converts attributes from snake case to camel case' do
+  it 'returns item with camelCase attributes' do
     item = FactoryBot.create(:item, name: 'FooBar', sell_in: 5, quality: 11)
 
     presented_item = Api::V1::ItemPresenter.to_json(item)
 
     expect(presented_item).to include(:sellIn)
     expect(presented_item).not_to include(:sell_in)
+  end
+
+  it 'converts camelCase params to snake_case' do
+    item_presenter = Api::V1::ItemPresenter
+    params = {name: 'FooBar', sellIn: 5, quality: 11}
+
+    actual = item_presenter.snakecase_keys(params)
+    expected = {'name' => 'FooBar', 'quality' => 11, 'sell_in' => 5}
+
+    expect(actual).to eq(expected)
+  end
+
+  it 'it doesnt return extra params' do
+    item_presenter = Api::V1::ItemPresenter
+    params = {name: 'FooBar', sellIn: 5, quality: 11, fooBar: 5}
+
+    actual = item_presenter.snakecase_keys(params)
+    expected = {'name' => 'FooBar', 'quality' => 11, 'sell_in' => 5}
+
+    expect(actual).to eq(expected)
+  end
+
+  it 'returns unsupplied required params set to nil' do
+    item_presenter = Api::V1::ItemPresenter
+    params = {name: 'FooBar', sellIn: 5}
+
+    actual = item_presenter.snakecase_keys(params)
+    expected = {'name' => 'FooBar', 'sell_in' => 5, 'quality' => nil}
+
+    expect(actual).to eq(expected)
+  end
+
+  it 'returns empty string params as an empty string' do
+    item_presenter = Api::V1::ItemPresenter
+    params = {name: '', sellIn: 5, quality: 5}
+
+    actual = item_presenter.snakecase_keys(params)
+    expected = {'name' => '', 'sell_in' => 5, 'quality' => 5}
+
+    expect(actual).to eq(expected)
+  end
+
+  it 'returns nil attributes as nil' do
+    item_presenter = Api::V1::ItemPresenter
+    params = {name: 'FooBar', sellIn: 5, quality: nil}
+
+    actual = item_presenter.snakecase_keys(params)
+    expected = {'name' => 'FooBar', 'sell_in' => 5, 'quality' => nil}
+
+    expect(actual).to eq(expected)
   end
 end

--- a/spec/requests/items_spec.rb
+++ b/spec/requests/items_spec.rb
@@ -95,13 +95,13 @@ RSpec.describe 'Items API', type: :request do
   describe 'POST api/v1/items' do
     context 'when item post request attributes are valid' do
       it 'creates a new item in the database' do
-        valid_attributes = {name: 'Asparagus', sell_in: 10, quality: 25}
+        valid_attributes = {name: 'Asparagus', sellIn: 10, quality: 25}
 
         expect { post '/api/v1/items', params: valid_attributes }.to change(Item, :count).by(+1)
       end
 
       it 'returns status code 201' do
-        valid_attributes = {name: 'Asparagus', sell_in: 10, quality: 25}
+        valid_attributes = {name: 'Asparagus', sellIn: 10, quality: 25}
         post '/api/v1/items', params: valid_attributes
 
         expect(response).to have_http_status(201)


### PR DESCRIPTION
## Summary 

The `snake-case-params` adds a presenter class method to convert the camelcased sellIn parameter to snake_case. The method is used in the Item create controller action to convert strong params to ruby syntax convention. 