### PR TITLE
Add item seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,10 @@
-# frozen_string_literal: true
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+Item.destroy_all
+
+Item.create!(
+  [
+    { name: 'Aged Brie', sell_in: 7, quality: 5},
+    { name: 'Backstage passes to a TAFKAL80ETC concert', sell_in: 21, quality: 3},
+    { name: 'Sulfuras, Hand of Ragnaros', sell_in: 14, quality: 100},
+    { name: 'Conjured Cauldron of Congee', sell_in: 10, quality: 10}
+    ]
+  )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,10 +1,8 @@
-Item.destroy_all
-
-Item.create!(
-  [
-    { name: 'Aged Brie', sell_in: 7, quality: 5},
-    { name: 'Backstage passes to a TAFKAL80ETC concert', sell_in: 21, quality: 3},
-    { name: 'Sulfuras, Hand of Ragnaros', sell_in: 14, quality: 100},
-    { name: 'Conjured Cauldron of Congee', sell_in: 10, quality: 10}
-    ]
-  )
+# frozen_string_literal: true
+# This file should contain all the record creation needed to seed the database with its default values.
+# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
+#
+# Examples:
+#
+#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
+#   Character.create(name: 'Luke', movie: movies.first)

--- a/lib/tasks/seed_task.rake
+++ b/lib/tasks/seed_task.rake
@@ -1,0 +1,12 @@
+desc 'Seed client provided item data to database'
+task add_item_seeds: :environment do
+  Item.create!(
+      [
+        { name: 'Aged Brie', sell_in: 7, quality: 5},
+        { name: 'Backstage passes to a TAFKAL80ETC concert', sell_in: 21, quality: 3},
+        { name: 'Sulfuras, Hand of Ragnaros', sell_in: 14, quality: 100},
+        { name: 'Conjured Cauldron of Congee', sell_in: 10, quality: 10}
+      ]
+    )
+  puts "Created #{Item.count} items!"
+end


### PR DESCRIPTION
## Summary ## 
The `add-data-seeds` branch is adding the existing item data supplied by the client to the seeds. 