### PR TITLE
Add environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,7 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 
+# Ignore auth credentials environment variables.
+/config/auth_credentials.rb
+
 **/.DS_Store

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -1,7 +1,7 @@
 require_relative "item_presenter"
 
 class Api::V1::ItemsController < ApplicationController
-  http_basic_authenticate_with name: Rails.application.credentials.username, password: Rails.application.credentials.password, only: :create
+  http_basic_authenticate_with name: ENV["USERNAME"], password: ENV["PASSWORD"], only: :create
 
   def index
     items = Item.all.map do |item|

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,5 +3,9 @@
 # Load the Rails application.
 require_relative 'application'
 
+#load test_set.rb
+app_test = File.join(Rails.root, 'config', 'auth_credentials.rb')
+load(app_test) if File.exist?(app_test)
+
 # Initialize the Rails application.
 Rails.application.initialize!


### PR DESCRIPTION
The `change-env-usage` branch changes the auth headers in the ItemsController to use ruby environment variables. This change will allow the environment variables to be added to heroku and CI for use during production. 