### PR TITLE
Add reviews

### DIFF
--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,0 +1,3 @@
+class Review < ApplicationRecord
+  belongs_to :item
+end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,3 +1,4 @@
 class Review < ApplicationRecord
   belongs_to :item
+  validates :text, presence: true
 end

--- a/db/migrate/20210716183129_create_reviews.rb
+++ b/db/migrate/20210716183129_create_reviews.rb
@@ -1,0 +1,10 @@
+class CreateReviews < ActiveRecord::Migration[6.1]
+  def change
+    create_table :reviews do |t|
+      t.string :text
+      t.references :item, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_28_183111) do
+ActiveRecord::Schema.define(version: 2021_07_16_183129) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,4 +24,13 @@ ActiveRecord::Schema.define(version: 2021_06_28_183111) do
     t.string "description"
   end
 
+  create_table "reviews", force: :cascade do |t|
+    t.string "text"
+    t.bigint "item_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_reviews_on_item_id"
+  end
+
+  add_foreign_key "reviews", "items"
 end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Review, type: :model do
+  subject do
+    bacon = Item.new(
+      name: "bacon",
+      sell_in: 4,
+      quality: 10,
+      description: "meat"
+    )
+
+    described_class.new(
+      item: bacon,
+      text: "delicious meat"
+    )
+  end
+
+  it "is valid with valid attributes" do
+    expect(subject).to be_valid
+  end
+
+  it "is not valid without text"
+end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -1,26 +1,28 @@
 require "rails_helper"
 
 RSpec.describe Review, type: :model do
-  subject do
-    bacon = Item.new(
+  before(:each) do
+    @bacon = Item.new(
       name: "bacon",
       sell_in: 4,
       quality: 10,
       description: "meat"
     )
-
-    described_class.new(
-      item: bacon,
-      text: "delicious meat"
-    )
   end
 
   it "is valid with valid attributes" do
+    subject = described_class.new(
+      item: @bacon,
+      text: "delicious meat"
+    )
     expect(subject).to be_valid
   end
 
   it "is not valid without text" do
-    subject.text = nil
+    subject = described_class.new(
+      item: @bacon,
+      text: nil
+    )
     expect(subject).to_not be_valid
   end
 end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -19,5 +19,8 @@ RSpec.describe Review, type: :model do
     expect(subject).to be_valid
   end
 
-  it "is not valid without text"
+  it "is not valid without text" do
+    subject.text = nil
+    expect(subject).to_not be_valid
+  end
 end


### PR DESCRIPTION
## Summary
The `add-reviews` branch adds a new table for reviews. a review has a required text: string attribute and requires has a many-one relationship with items. 


## Future Work
- Update Readme
- Currently validation only occurs at the rails level. this will be supplemented by adding database constraints.
- Add endpoint `/api/v1/items/:item-id/reviews` to get all reviews for an item
- Handle item delete (probably cascade...)(maybe not needed since item delete is not currently a feature)