### PR TITLE
added not null database constraint to review:text

### DIFF
--- a/db/migrate/20210719151920_change_review_text_constraint.rb
+++ b/db/migrate/20210719151920_change_review_text_constraint.rb
@@ -1,0 +1,5 @@
+class ChangeReviewTextConstraint < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :reviews, :text, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_16_183129) do
+ActiveRecord::Schema.define(version: 2021_07_19_151920) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(version: 2021_07_16_183129) do
   end
 
   create_table "reviews", force: :cascade do |t|
-    t.string "text"
+    t.string "text", null: false
     t.bigint "item_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -32,6 +32,6 @@ RSpec.describe Review, type: :model do
       text: nil
     )
 
-    expect {subject.save!(validate: false) }.to raise_error(ActiveRecord::NotNullViolation, /PG::NotNullViolation/)
+    expect {subject.save!(validate: false) }.to raise_error(ActiveRecord::NotNullViolation)
   end
 end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -25,4 +25,13 @@ RSpec.describe Review, type: :model do
     )
     expect(subject).to_not be_valid
   end
+
+  it "raises PG database error without text" do
+    subject = described_class.new(
+      item: @bacon,
+      text: nil
+    )
+
+    expect {subject.save!(validate: false) }.to raise_error(ActiveRecord::NotNullViolation, /PG::NotNullViolation/)
+  end
 end


### PR DESCRIPTION
## Summary
The `add-database-constraints` branch adds a database level not null constraint to the review: text field. 


## Future Work
- Update Readme
- Add endpoint `/api/v1/items/:item-id/reviews` to get all reviews for an item
- Handle item delete (probably cascade...)(maybe not needed since item delete is not currently a feature)