### PR TITLE
Add review nested route

### DIFF
--- a/app/controllers/api/v1/reviews_controller.rb
+++ b/app/controllers/api/v1/reviews_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::ReviewsController < ApplicationController
+  def index
+    item = Item.find(params[:item_id])
+    reviews = item.reviews.map { |review| review.text }
+    json_response(reviews)
+  end
+end

--- a/app/controllers/api/v1/reviews_controller.rb
+++ b/app/controllers/api/v1/reviews_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::ReviewsController < ApplicationController
   def index
     item = Item.find(params[:item_id])
-    reviews = item.reviews.map { |review| review.text }
+    reviews = item.reviews
     json_response(reviews)
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,4 +2,5 @@ class Item < ActiveRecord::Base
   validates :name, presence: true, uniqueness: true
   validates :sell_in, presence: true
   validates :quality, presence: true
+  has_many :reviews
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,8 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get "/welcome", to: "welcome#index"
-      resources :items do
-        resources :reviews
+      resources :items, only: [:index, :show, :create] do
+        resources :reviews, only: [:index]
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get "/welcome", to: "welcome#index"
-      resources :items
+      resources :items do
+        resources :reviews
+      end
     end
   end
 end

--- a/spec/factories/review.rb
+++ b/spec/factories/review.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :review, class: Review do
+    text { "a good item" }
+    item { association :item }
+  end
+end

--- a/spec/requests/reviews_spec.rb
+++ b/spec/requests/reviews_spec.rb
@@ -19,6 +19,15 @@ RSpec.describe "Reviews API", type: :request do
       expect(json.size).to eq(1)
     end
 
+    it "returns the correct review text" do
+      FactoryBot.create(:item, id: 1)
+      FactoryBot.create(:review, text: "5 out of 5 stars", item: Item.find(1))
+
+      get "/api/v1/items/1/reviews"
+
+      expect(json[0]["text"]).to eq("5 out of 5 stars")
+    end
+
     it "returns many reviews as a list" do
       FactoryBot.create(:item, id: 1)
       FactoryBot.create(:review, item: Item.find(1))

--- a/spec/requests/reviews_spec.rb
+++ b/spec/requests/reviews_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe "Reviews API", type: :request do
+  describe "GET /api/v1/items/:item_id/reviews" do
+    it "returns an empty list when no items" do
+      FactoryBot.create(:item, id: 1)
+
+      get "/api/v1/items/1/reviews"
+      expect(response).to have_http_status(:success)
+      expect(json.size).to eq(0)
+    end
+
+    it "returns a single review as a list" do
+      FactoryBot.create(:item, id: 1)
+      FactoryBot.create(:review, item: Item.find(1))
+
+      get "/api/v1/items/1/reviews"
+      expect(response).to have_http_status(:success)
+      expect(json.size).to eq(1)
+    end
+
+    it "returns many reviews as a list" do
+      FactoryBot.create(:item, id: 1)
+      FactoryBot.create(:review, item: Item.find(1))
+      FactoryBot.create(:review, item: Item.find(1))
+
+      get "/api/v1/items/1/reviews"
+      expect(response).to have_http_status(:success)
+      expect(json.size).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
The `add-review-nested-route` branch adds routing for review, specifically it allows the route of `get /v1/api/items/:item_id/reviews` which returns a list of reviews associated with `:item_id` 

## Future Work
- Update Readme
- Handle item delete (probably cascade...)(maybe not needed since item delete is not currently a feature)