### PR TITLE
added review presenter

### DIFF
--- a/app/controllers/api/v1/review_presenter.rb
+++ b/app/controllers/api/v1/review_presenter.rb
@@ -1,0 +1,9 @@
+class Api::V1::ReviewPresenter < ApplicationController
+  attr_accessor :review
+
+  def self.to_json(review)
+    {
+      text: review.text
+    }
+  end
+end

--- a/app/controllers/api/v1/reviews_controller.rb
+++ b/app/controllers/api/v1/reviews_controller.rb
@@ -2,6 +2,6 @@ class Api::V1::ReviewsController < ApplicationController
   def index
     item = Item.find(params[:item_id])
     reviews = item.reviews
-    json_response(reviews)
+    json_response({reviews: reviews})
   end
 end

--- a/spec/requests/review_presenter_spec.rb
+++ b/spec/requests/review_presenter_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe Api::V1::ReviewPresenter do
+  describe ".to_json" do
+    it "returns a review with just text attribute" do
+      item = FactoryBot.create(
+        :item,
+          name: "campbell's soup",
+          sell_in: 2,
+          quality: 10,
+          description: "chicken broth with noodles"
+      )
+      review = FactoryBot.create(
+        :review,
+          text: "mmm mmm good",
+          item: item
+      )
+
+      presented_review = Api::V1::ReviewPresenter.to_json(review)
+
+      expect(presented_review).to include(:text)
+      expect(presented_review).not_to include(:id)
+      expect(presented_review).not_to include(:item)
+      expect(presented_review).not_to include(:created_at)
+      expect(presented_review).not_to include(:updated_at)
+    end
+  end
+end

--- a/spec/requests/reviews_spec.rb
+++ b/spec/requests/reviews_spec.rb
@@ -2,12 +2,21 @@ require "rails_helper"
 
 RSpec.describe "Reviews API", type: :request do
   describe "GET /api/v1/items/:item_id/reviews" do
-    it "returns an empty list when no items" do
+    it "returns a nested json object containing reviews element" do
       FactoryBot.create(:item, id: 1)
 
       get "/api/v1/items/1/reviews"
       expect(response).to have_http_status(:success)
-      expect(json.size).to eq(0)
+      expect(json.size).to eq(1)
+      expect(json).to include("reviews")
+    end
+
+    it "returns an empty list of reviews when no items" do
+      FactoryBot.create(:item, id: 1)
+
+      get "/api/v1/items/1/reviews"
+      expect(response).to have_http_status(:success)
+      expect(json["reviews"].size).to eq(0)
     end
 
     it "returns a single review as a list" do
@@ -16,7 +25,7 @@ RSpec.describe "Reviews API", type: :request do
 
       get "/api/v1/items/1/reviews"
       expect(response).to have_http_status(:success)
-      expect(json.size).to eq(1)
+      expect(json["reviews"].size).to eq(1)
     end
 
     it "returns the correct review text" do
@@ -25,7 +34,7 @@ RSpec.describe "Reviews API", type: :request do
 
       get "/api/v1/items/1/reviews"
 
-      expect(json[0]["text"]).to eq("5 out of 5 stars")
+      expect(json["reviews"][0]["text"]).to eq("5 out of 5 stars")
     end
 
     it "returns many reviews as a list" do
@@ -35,7 +44,7 @@ RSpec.describe "Reviews API", type: :request do
 
       get "/api/v1/items/1/reviews"
       expect(response).to have_http_status(:success)
-      expect(json.size).to eq(2)
+      expect(json["reviews"].size).to eq(2)
     end
   end
 end


### PR DESCRIPTION
## Summary
The `finish-add-review` branch finishes the nested routing for review, specifically it structures the json response as a nested response ala { "reviews": [] } it also adds an explicit review presenter to only return the review text instead of all database elements from the review table.

## Future Work
- Handle item delete case for related reviews (probably cascade...)(if/when we add item delete as a feature)